### PR TITLE
The concept item is defined multipe times

### DIFF
--- a/_data/entities.yaml
+++ b/_data/entities.yaml
@@ -44,15 +44,6 @@ user:
   broader: entity
   narrower: [user, perpetrator, donation]
 
-item:
-  id: item
-  type: concept
-  prefLabel: Item
-  description: >
-    A digital or non-digital item.
-  broader: entity
-  narrower: collectible
-
 service:
   id: service
   type: concept


### PR DESCRIPTION
I noticed that the concept *item* was defined multiple times. Under top-level concepts and again under specific concepts. Don't know if that is intended. 

By default duplicate keys are not allowed in yaml files (http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys)

Came across this while working on this issue (https://github.com/graphsense/graphsense-tagpack-tool/issues/50)